### PR TITLE
Add Python 3 support

### DIFF
--- a/apricotpy/event_loop.py
+++ b/apricotpy/event_loop.py
@@ -185,7 +185,7 @@ class BaseEventLoop(AbstractEventLoop):
     def objects(self, obj_type=None):
         # Filter the type if necessary
         if obj_type is not None:
-            return [obj for obj in self._objects.itervalues() if isinstance(obj, obj_type)]
+            return [obj for obj in self._objects.values() if isinstance(obj, obj_type)]
         else:
             return self._objects.values()
 

--- a/apricotpy/events.py
+++ b/apricotpy/events.py
@@ -8,6 +8,8 @@ import sys
 import threading
 import traceback
 
+from future.utils import with_metaclass
+
 __all__ = ['AbstractEventLoopPolicy',
            'AbstractEventLoop',
            'Handle', 'TimerHandle',
@@ -187,8 +189,7 @@ class TimerHandle(Handle):
         return NotImplemented if equal is NotImplemented else not equal
 
 
-class AbstractEventLoop(object):
-    __metaclass__ = abc.ABCMeta
+class AbstractEventLoop(with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractmethod
     def create_future(self):
@@ -261,7 +262,7 @@ class AbstractEventLoop(object):
         Get the objects in the event loop.  Optionally filer for loop objects of
         a given type.
 
-        :param obj_type: The loop object class to filter for. 
+        :param obj_type: The loop object class to filter for.
         :return: A list of the found objects.
         """
         pass
@@ -271,7 +272,7 @@ class AbstractEventLoop(object):
         """
         Create a task and schedule it to be inserted into the loop.
 
-        :param object_type: The task identifier 
+        :param object_type: The task identifier
         :param args: (optional) positional arguments to the task
         :param kwargs: (optional) keyword arguments to the task
 
@@ -284,7 +285,7 @@ class AbstractEventLoop(object):
         """
         Create a task and schedule it to be inserted into the loop.
 
-        :param object_type: The task identifier 
+        :param object_type: The task identifier
         :param args: (optional) positional arguments to the task
         :param kwargs: (optional) keyword arguments to the task
 
@@ -297,7 +298,7 @@ class AbstractEventLoop(object):
         """
         Schedule an object to be removed an object from the event loop.
 
-        :param loop_object: The object to remove 
+        :param loop_object: The object to remove
         :return: A future corresponding to the removal of the object
         """
         pass
@@ -313,7 +314,7 @@ class AbstractEventLoop(object):
         where task is some task identifier and positional and keyword arguments
         can be supplied and it returns the :class:`Task` instance.
 
-        :param factory: The task factory 
+        :param factory: The task factory
         """
         pass
 
@@ -364,10 +365,8 @@ class AbstractEventLoop(object):
         # endregion
 
 
-class AbstractEventLoopPolicy(object):
+class AbstractEventLoopPolicy(with_metaclass(abc.ABCMeta, object)):
     """Abstract policy for accessing the event loop."""
-
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def get_event_loop(self):

--- a/apricotpy/futures.py
+++ b/apricotpy/futures.py
@@ -3,6 +3,8 @@ import concurrent.futures
 import sys
 import traceback
 
+from future.utils import with_metaclass 
+
 from . import events
 
 __all__ = ['CancelledError', 'Awaitable', 'Future',
@@ -21,11 +23,10 @@ _CANCELLED = 'CANCELLED'
 _FINISHED = 'FINISHED'
 
 
-class Awaitable(object):
+class Awaitable(with_metaclass(abc.ABCMeta, object)):
     """
     An interface that defines an object that is awaitable e.g. a Future
     """
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def done(self):
@@ -183,7 +184,7 @@ class Future(Awaitable):
     def add_done_callback(self, fn):
         """
         Add a callback to be run when the future becomes done.
-        
+
         :param fn: The callback function.
         """
         if self.done():
@@ -208,7 +209,7 @@ class Future(Awaitable):
     def _schedule_callbacks(self):
         """
         Ask the event loop to call all callbacks.
-        
+
         The callbacks are scheduled to be called as soon as possible.
         """
         callbacks = self._callbacks[:]
@@ -269,8 +270,8 @@ _GatheringFuture = _gathering_future_template(Future)
 def gather(awaitables, loop):
     """
     Gather multiple awaitables into a single :class:`Awaitable`
-    
-    :param awaitables: The awaitables to gather 
+
+    :param awaitables: The awaitables to gather
     :param loop: The event loop
     :return: An awaitable representing all the awaitables
     :rtype: :class:`Awaitable`

--- a/apricotpy/messages.py
+++ b/apricotpy/messages.py
@@ -71,9 +71,9 @@ class Mailman(object):
         with self._listeners_lock:
             if subject is None:
                 # This means remove ALL messages for this listener
-                for evt in self._specific_listeners.keys():
+                for evt in list(self._specific_listeners.keys()):
                     self._remove_specific_listener(listener, evt)
-                for evt in self._wildcard_listeners.keys():
+                for evt in list(self._wildcard_listeners.keys()):
                     self._remove_wildcard_listener(listener, evt)
             else:
                 if self.contains_wildcard(subject):
@@ -103,9 +103,9 @@ class Mailman(object):
         """
         with self._listeners_lock:
             total = 0
-            for listeners in self._specific_listeners.itervalues():
+            for listeners in self._specific_listeners.values():
                 total += len(listeners)
-            for entry in self._wildcard_listeners.itervalues():
+            for entry in self._wildcard_listeners.values():
                 total += len(entry.listeners)
             return total
 

--- a/apricotpy/messages.py
+++ b/apricotpy/messages.py
@@ -2,17 +2,19 @@ from collections import namedtuple
 import threading
 import re
 
+from past.builtins import basestring
+
 _WilcardEntry = namedtuple("_WildcardEntry", ['re', 'listeners'])
 
 
 class Mailman(object):
     """
     A class to send messages to listeners
-    
+
     Messages send by this class:
     * mailman.listener_added.[subject]
     * mailman.listener_removed.[subject]
-    
+
     where subject is the subject the listener is listening for
     """
 
@@ -22,7 +24,7 @@ class Mailman(object):
         Does the event string contain a wildcard.
 
         :param event: The event string
-        :type event: str or unicode
+        :type event: basestring
         :return: True if it does, False otherwise
         """
         return event.find('*') != -1 or event.find('#') != -1
@@ -45,7 +47,7 @@ class Mailman(object):
         :param listener: The listener callback function to call when the
             event happens
         :param subject: A subject string
-        :type subject: str or unicode
+        :type subject: basestring
         """
         if subject is None:
             raise ValueError("Invalid event '{}'".format(subject))
@@ -64,7 +66,7 @@ class Mailman(object):
 
         :param listener: The listener that is currently listening
         :param subject: (optional) subject to stop listening for
-        :type subject: str or unicode
+        :type subject: basestring
         """
         with self._listeners_lock:
             if subject is None:
@@ -110,10 +112,10 @@ class Mailman(object):
     def send(self, subject, body=None, sender_id=None):
         """
         Send a message
-        
-        :param subject: The message subject 
+
+        :param subject: The message subject
         :param body: The body of the message
-        :param sender_id: An identifier for the sender, if LoopObject this will 
+        :param sender_id: An identifier for the sender, if LoopObject this will
             be the UUID.
         """
         # These loops need to use copies because, e.g., the recipient may

--- a/apricotpy/objects.py
+++ b/apricotpy/objects.py
@@ -3,6 +3,8 @@ import sys
 import traceback
 import uuid
 
+from future.utils import with_metaclass 
+
 from . import futures
 
 __all__ = ['LoopObject',
@@ -71,17 +73,16 @@ class LoopObject(object):
     def send_message(self, subject, body=None):
         """
         Send a message from this object.  The UUID will automatically be used
-        as the sender id. 
+        as the sender id.
         """
         self.loop().messages().send(subject, body, self.uuid)
 
 
-class TickingMixin(object):
+class TickingMixin(with_metaclass(abc.ABCMeta, object)):
     """
     A mixin that makes a LoopObject be 'ticked' each time around the event
     loop.  The user code should go in the `tick()` function.
     """
-    __metaclass__ = abc.ABCMeta
 
     def on_loop_inserted(self, loop):
         super(TickingMixin, self).on_loop_inserted(loop)

--- a/apricotpy/persistable/core.py
+++ b/apricotpy/persistable/core.py
@@ -4,6 +4,10 @@ import collections
 import inspect
 import logging
 import uuid
+
+from past.builtins import basestring
+from future.utils import with_metaclass
+
 from . import utils
 
 __all__ = ['LoopPersistable', 'Bundle', 'Unbundler']
@@ -13,11 +17,10 @@ _NULL = tuple()
 _KEY_CLASS_LOADER = 'class_loader'
 
 
-class LoopPersistable(object):
+class LoopPersistable(with_metaclass(abc.ABCMeta, object)):
     """
     An abstract class that defines objects that are persistable.
     """
-    __metaclass__ = abc.ABCMeta
 
     # Class variables serving as defaults for instance variables.
     _persistable_id = None
@@ -27,11 +30,11 @@ class LoopPersistable(object):
         """
         Overwrite this if you want to provide your own persistable ID, e.g.
         because you already have a UUID.
-        
+
         Be careful though, this ID should be a unique type that identifies this
         _instance_!  And must be of a type that can be saved in :class:`Bundle`
-        
-        :return: A persistable id that identifies this instance 
+
+        :return: A persistable id that identifies this instance
         """
         if self._persistable_id is None:
             self._persistable_id = uuid.uuid4()
@@ -68,7 +71,7 @@ class _Reference(collections.Hashable):
 class Bundle(dict):
     """
     This object represents the persisted state of a :class:`LoopPersistable` object.
-    
+
     When instantiating it will ask the persistable to save its instance state
     which will trigger any child persistables to also be saved.
     """
@@ -160,7 +163,7 @@ class Bundle(dict):
                 raise ValueError("Unsupported sequence type ({}), use a tuple".format(type(value)))
 
         if isinstance(value, dict):
-            return {k: self._encode(item) for k, item in value.iteritems()}
+            return {k: self._encode(item) for k, item in value.items()}
 
         if inspect.isfunction(value) or inspect.ismethod(value):
             from .persistables import Function
@@ -168,7 +171,7 @@ class Bundle(dict):
             fn_obj = Function(value)
             return self._ensure_bundle(fn_obj)
 
-        if isinstance(value, (int, float, str, unicode, uuid.UUID)):
+        if isinstance(value, (int, float, basestring, uuid.UUID)):
             return value
 
         if isinstance(value, BaseException):
@@ -204,7 +207,7 @@ class Bundle(dict):
 
 class Unbundler(collections.Mapping):
     """
-    The unbundler provides a readonly view of a bundle that is used while a 
+    The unbundler provides a readonly view of a bundle that is used while a
     persistable is reloading its state.
     """
 
@@ -285,7 +288,7 @@ class Unbundler(collections.Mapping):
             return tuple(self.decode(item) for item in value)
 
         if isinstance(value, dict):
-            return {k: self.decode(item) for k, item in value.iteritems()}
+            return {k: self.decode(item) for k, item in value.items()}
 
         return value
 

--- a/apricotpy/persistable/core.py
+++ b/apricotpy/persistable/core.py
@@ -62,7 +62,7 @@ class _Reference(collections.Hashable):
         return hash(self.id)
 
     def __eq__(self, other):
-        return self.id == other
+        return self.id == other.id
 
     def __repr__(self):
         return "<Reference {}>".format(self.id)

--- a/apricotpy/persistable/event_loop.py
+++ b/apricotpy/persistable/event_loop.py
@@ -98,7 +98,7 @@ class BaseEventLoop(apricotpy.BaseEventLoop, objects.LoopObject):
 
         to_save = dict(self._objects)
         # Remove those that are not savable
-        for uuid, obj in self._objects.iteritems():
+        for uuid, obj in self._objects.items():
             if not isinstance(obj, core.LoopPersistable):
                 _LOGGER.warning("Not saving object '{}', it is not persistable".format(obj))
                 to_save.pop(uuid)

--- a/apricotpy/persistable/serialisation.py
+++ b/apricotpy/persistable/serialisation.py
@@ -1,11 +1,13 @@
 import abc
 import os
 import pickle
+
+from future.utils import with_metaclass
+
 from . import core
 
 
-class Persister(object):
-    __metaclass__ = abc.ABCMeta
+class Persister(with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractmethod
     def serialise_state(self, saved_state):

--- a/apricotpy/persistable/tasks.py
+++ b/apricotpy/persistable/tasks.py
@@ -1,4 +1,6 @@
-from abc import ABCMeta
+import abc
+
+from future.utils import with_metaclass
 
 import apricotpy.tasks
 from . import awaitable
@@ -9,11 +11,11 @@ _NO_RESULT = apricotpy.tasks._NO_RESULT
 __all__ = ['Task']
 
 
-class Task(
+class Task(with_metaclass(
+    abc.ABCMeta,
     awaitable.MakeAwaitableMixinPersistable,  # make Awaitable also LoopPersistable
     apricotpy.tasks.TaskMixin,
-    objects.LoopObject):
-    __metaclass__ = ABCMeta
+    objects.LoopObject)):
 
     AWAITING = 'AWAITING'
     AWAITING_RESULT = 'AWAITING_RESULT'

--- a/apricotpy/persistable/utils.py
+++ b/apricotpy/persistable/utils.py
@@ -39,13 +39,16 @@ class ClassLoader(object):
         return self.find_class(name)
 
 def function_name(fn):
-    if inspect.ismethod(fn):
-        cls = fn.__self__.__class__
-        name = class_name(cls) + '.' + fn.__name__
-    elif inspect.isfunction(fn):
-        name = fn.__module__ + '.' + fn.__name__
-    else:
-        raise ValueError("Must be function or method")
+    try:
+        name = fn.__module__ + '.' + fn.__qualname__
+    except AttributeError:
+        if inspect.ismethod(fn):
+            cls = fn.__self__.__class__
+            name = class_name(cls) + '.' + fn.__name__
+        elif inspect.isfunction(fn):
+            name = fn.__module__ + '.' + fn.__name__
+        else:
+            raise ValueError("Must be function or method")
 
     # Make sure we can load it
     try:

--- a/apricotpy/persistable/utils.py
+++ b/apricotpy/persistable/utils.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import uuid
 
+from past.builtins import basestring
 
 class UuidMixin(object):
     def __init__(self, *args, **kwargs):
@@ -150,10 +151,10 @@ def is_sequence_not_str(value):
     """
     A helper to check if a value is of type :class:`collections.Sequence`
     but not a string type (i.e. :class:`str` or :class:`unicode`)
-    
-    :param value: The value to check 
+
+    :param value: The value to check
     :return: True of a sequence but not string, False otherwise
     :rtype: bool
     """
     return isinstance(value, collections.Sequence) and \
-           not isinstance(value, (str, unicode))
+           not isinstance(value, basestring)

--- a/apricotpy/tasks.py
+++ b/apricotpy/tasks.py
@@ -3,6 +3,8 @@ import logging
 from collections import namedtuple
 import traceback
 
+from future.utils import with_metaclass
+
 from . import objects
 from . import futures
 
@@ -31,8 +33,7 @@ class Await(_TaskDirective):
 _NO_RESULT = ()
 
 
-class TaskMixin(objects.AwaitableMixin):
-    __metaclass__ = abc.ABCMeta
+class TaskMixin(with_metaclass(abc.ABCMeta, objects.AwaitableMixin)):
 
     Terminated = namedtuple("Terminated", ['result'])
 
@@ -174,7 +175,10 @@ class TaskMixin(objects.AwaitableMixin):
             self._schedule_step()
 
 
-class Task(TaskMixin, objects.LoopObject):
+class Task(with_metaclass(
+        abc.ABCMeta,
+        TaskMixin, objects.LoopObject
+    )):
     """
     A task is an awaitable loop object which has an execute() method
     that will be called when it is inserted into the loop.
@@ -184,4 +188,3 @@ class Task(TaskMixin, objects.LoopObject):
 
 
     """
-    __metaclass__ = abc.ABCMeta

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
     # http://blog.miguelgrinberg.com/post/the-package-dependency-blues
     # for a useful dicussion
     install_requires=[
+        'future'
     ],
     extras_require={
         ':python_version<"3.4"': ['enum34'],

--- a/test/test_event_loop.py
+++ b/test/test_event_loop.py
@@ -56,7 +56,7 @@ class TestEventLoop(unittest.TestCase):
             raise RuntimeError('Test error!')
         except RuntimeError as e:
             context = {
-                'message': e.message,
+                'message': str(e),
                 'exception': e,
             }
             self.loop.default_exception_handler(context)
@@ -67,7 +67,7 @@ class TestEventLoop(unittest.TestCase):
         except RuntimeError as e:
             e.__traceback__ = None
             context = {
-                'message': e.message,
+                'message': str(e),
                 'exception': e,
             }
             self.loop.default_exception_handler(context)


### PR DESCRIPTION
Things changed:

* Use ``past.builtins.basestring`` instead of ``str`` and ``unicode``
* Use ``future.utils.with_metaclass`` to define metaclasses
* Use ``str(e)`` instead of ``e.message`` to get the exception message
* Use ``__qualname__`` for Python 3 in ``function_name`` because ``inspect.ismethod`` only returns ``True`` if the function is bound to an instance, not a class.